### PR TITLE
[FEAT] Add github release to cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:
@@ -72,3 +72,19 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          body: |
+            **ghscope** ${{ env.PACKAGE_VERSION }}
+            - Install: `pip install ghscope`
+            - [PyPI](https://pypi.org/project/ghscope/${{ env.PACKAGE_VERSION }}/)
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the continuous deployment workflow to improve automation around releases. The most important changes are:

**Workflow permissions:**

* Changed the `contents` permission from `read` to `write` in `.github/workflows/cd.yml` to allow the workflow to create GitHub releases.

**Release automation:**

* Added a new step to the workflow that uses `softprops/action-gh-release@v2` to automatically create a GitHub Release after publishing to PyPI, attaching the built distribution files and generating release notes.

Closes #2 